### PR TITLE
Rework grocery interface with mobile-first polish

### DIFF
--- a/docs/grocery/index.html
+++ b/docs/grocery/index.html
@@ -3,157 +3,514 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+<meta http-equiv="Cache-Control" content="no-store, max-age=0"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
 <title>Ashbaugh–Alomary Grocery List</title>
 <meta name="robots" content="noindex,nofollow,noarchive,nosnippet,noimageindex"/>
 <meta name="googlebot" content="noindex,nofollow,noarchive,nosnippet,noimageindex"/>
 
 <style>
   :root{
-    --bg:#0b1220; --card:#0f172a; --ink:#e5e7eb; --muted:#9ca3af; --line:#22314b;
-    --brand:#4f8cff; --brand2:#2e6fff; --chip:#131e33; --chip2:#0f1a2d;
-    --ok:#22c55e; --bad:#ef4444;
-    --h:40px;          /* compact, still thumb-friendly */
-    --r:12px;          /* radius */
-    --sp:10px;         /* spacing */
+    color-scheme:dark;
+    --bg:#050810;
+    --bg-accent:rgba(40,70,130,.22);
+    --card:#0b1323;
+    --panel:#121c33;
+    --ink:#f1f5f9;
+    --muted:#9aa9c4;
+    --line:rgba(94,129,255,.3);
+    --brand:#6c8bff;
+    --brand-strong:#3d68ff;
+    --accent:#2dd4bf;
+    --warn:#f87171;
+    --radius:18px;
+    --field-radius:14px;
+    --shadow:0 18px 38px rgba(5,8,16,.45);
+    --header-offset:calc(env(safe-area-inset-top) + 18px);
   }
   *{box-sizing:border-box}
   html,body{height:100%}
-  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Arial}
-
-  .wrap{max-width:880px;margin:0 auto;padding:14px 14px calc(76px + env(safe-area-inset-bottom))}
-  header{display:flex;align-items:center;gap:8px;margin-bottom:10px}
-  .logo{font-size:24px}
-  h1{font-size:18px;margin:0}
-  .status{margin-left:auto;background:#10261b;border:1px solid #1b4d3a;color:#86efac;border-radius:999px;padding:4px 8px;font-size:12px;display:flex;gap:6px;align-items:center}
-  .status.off{background:#2a1212;border-color:#4d1b1b;color:#fca5a5}
-  .dot{width:8px;height:8px;border-radius:50%;background:var(--ok)}
-
-  .seg{display:flex;background:var(--chip2);border:1px solid var(--line);border-radius:999px;overflow:hidden;margin:6px 0 10px}
-  .seg button{flex:1;border:0;background:transparent;color:var(--muted);padding:8px 0;font-weight:700}
-  .seg button.active{background:var(--brand);color:#fff}
-
-  .input{background:#0b1220;border:1px solid var(--line);border-radius:var(--r);height:var(--h);padding:0 12px;color:var(--ink)}
-  .btn{background:var(--brand);border:0;color:#fff;border-radius:var(--r);height:var(--h);padding:0 14px;font-weight:800}
-  .btn.secondary{background:var(--chip)}
-  .row-top{display:flex;gap:8px;align-items:center}
-
-  .list{display:flex;flex-direction:column;gap:8px;margin-top:10px}
-  .secHeader{display:flex;align-items:center;gap:8px;background:var(--chip);border:1px solid var(--line);padding:8px 10px;border-radius:10px}
-  .pill{background:#0f1b2e;border:1px solid #1a2946;color:#cdd9ff;border-radius:999px;padding:3px 8px;font-size:12px}
-  .secHeader .btn{height:32px;padding:0 10px}
-
-  /* Row card (compact, no swipe) */
-  .card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:10px}
-  .name[contenteditable]{outline:0;border-radius:10px;padding:6px 10px;font-size:16px;line-height:1.2;background:#0b1220;border:1px solid #1a2744}
-  .rowGrid{display:grid;grid-template-columns: 1fr 1fr auto auto auto; gap:8px; align-items:center; margin-top:8px}
-  .select{background:#0b1220;border:1px solid var(--line);border-radius:10px;height:36px;color:var(--ink);width:100%}
-
-  .qty{display:flex;gap:6px;align-items:center}
-  .qty input{width:52px;height:36px;text-align:center;border:1px solid var(--line);border-radius:10px;background:#0b1220;color:var(--ink)}
-  .iconBtn{width:36px;height:36px;border-radius:10px;border:0;background:var(--brand);color:#fff;font-size:18px;font-weight:900}
-
-  .toggle{width:56px;height:30px;border-radius:16px;background:#1e2a44;border:1px solid #2f3d5c;position:relative;cursor:pointer}
-  .toggle::after{content:"";position:absolute;top:3px;left:3px;width:24px;height:24px;border-radius:50%;background:#fff;transition:.18s}
-  .toggle.on{background:var(--brand2);border-color:var(--brand2)}
-  .toggle.on::after{left:29px}
-  .twrap{display:flex;align-items:center;gap:6px;color:var(--muted);font-size:12px}
-
-  .delBtn{width:36px;height:36px;border-radius:10px;border:0;background:#d72d2d;color:#fff;font-weight:900}
-
-  /* Bottom sticky add bar */
-  .bar{position:fixed;left:0;right:0;bottom:0;z-index:5;background:linear-gradient(180deg,transparent,rgba(11,18,32,.9) 20%, rgba(11,18,32,.98) 55%);padding:8px 10px calc(8px + env(safe-area-inset-bottom))}
-  .barInner{max-width:880px;margin:0 auto;display:flex;gap:8px}
-  .bar .input{height:44px} .bar .btn{height:44px;padding:0 16px}
-
-  /* Desktop tweaks */
-  @media (min-width:760px){
-    .wrap{padding-bottom:110px}
-    .rowGrid{grid-template-columns: 1.1fr 1.1fr auto auto auto}
+  body{
+    margin:0;
+    background:
+      radial-gradient(140% 120% at 10% -20%,rgba(108,139,255,.28),transparent 70%),
+      radial-gradient(120% 120% at 90% 0%,rgba(45,212,191,.22),transparent 70%),
+      var(--bg);
+    color:var(--ink);
+    font:16px/1.5 "Inter", "SF Pro Display", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+    -webkit-font-smoothing:antialiased;
   }
 
-  /* Password gate */
-  #gate{position:fixed;inset:0;display:grid;place-items:center;background:linear-gradient(180deg,#0b1220,#0d1426);z-index:10}
-  #gate.hidden{display:none}
-  .gate-card{width:min(92vw,440px);background:var(--card);border:1px solid var(--line);border-radius:16px;padding:20px}
-  .gate-title{font-weight:800;font-size:18px;margin-bottom:4px}
-  .gate-sub{color:var(--muted);margin-bottom:12px}
-  .gate-row{display:flex;gap:8px}
-  .gate-input{flex:1;background:#0b1220;border:1px solid var(--line);border-radius:12px;color:var(--ink);padding:10px;height:44px}
-  .gate-btn{background:var(--brand);border:0;border-radius:12px;color:#fff;padding:0 14px;font-weight:700;height:44px}
-  .gate-err{min-height:16px;color:#fca5a5;margin-top:8px}
+  .wrap{
+    max-width:900px;
+    margin:0 auto;
+    padding:calc(36px + env(safe-area-inset-top)) 18px calc(140px + env(safe-area-inset-bottom));
+    display:flex;
+    flex-direction:column;
+    gap:18px;
+    min-height:100%;
+  }
+  header{
+    position:sticky;
+    top:var(--header-offset);
+    display:flex;
+    align-items:center;
+    gap:14px;
+    background:linear-gradient(150deg,rgba(18,28,48,.96),rgba(10,16,30,.92));
+    border:1px solid var(--line);
+    border-radius:22px;
+    padding:14px 18px;
+    box-shadow:var(--shadow);
+    backdrop-filter:blur(18px);
+    z-index:10;
+  }
+  .logo{font-size:28px;filter:drop-shadow(0 6px 12px rgba(0,0,0,.45))}
+  h1{font-size:20px;margin:0;font-weight:700;letter-spacing:.01em}
+  .status{
+    margin-left:auto;
+    display:flex;
+    align-items:center;
+    gap:8px;
+    padding:6px 12px;
+    border-radius:999px;
+    border:1px solid rgba(45,212,191,.35);
+    background:rgba(12,38,36,.68);
+    color:#bffae3;
+    font-size:12px;
+    font-weight:700;
+    letter-spacing:.08em;
+    text-transform:uppercase;
+  }
+  .status.off{background:rgba(51,16,24,.68);border-color:rgba(248,113,113,.5);color:#fecaca}
+  .status span[aria-hidden="true"]{width:10px;height:10px;border-radius:50%;display:inline-block;background:var(--accent);box-shadow:0 0 0 3px rgba(45,212,191,.22)}
+  .status.off span[aria-hidden="true"]{background:var(--warn);box-shadow:0 0 0 3px rgba(248,113,113,.22)}
 
-  .toast{position:fixed;bottom:68px;left:50%;transform:translateX(-50%) translateY(10px);background:#101826;border:1px solid var(--line);padding:8px 12px;border-radius:10px;font-size:13px;opacity:0;transition:.2s}
+  .seg{
+    display:flex;
+    gap:6px;
+    background:rgba(13,22,42,.78);
+    border:1px solid var(--line);
+    padding:6px;
+    border-radius:999px;
+    box-shadow:var(--shadow);
+  }
+  .seg button{
+    flex:1;
+    border:0;
+    background:transparent;
+    color:var(--muted);
+    padding:10px 0;
+    font-weight:700;
+    letter-spacing:.01em;
+    border-radius:999px;
+    transition:background .2s ease, color .2s ease, box-shadow .2s ease;
+  }
+  .seg button.active{
+    background:linear-gradient(135deg,var(--brand),var(--brand-strong));
+    color:#fff;
+    box-shadow:0 16px 26px rgba(108,139,255,.35);
+  }
+
+  .row-top{
+    display:flex;
+    flex-direction:column;
+    gap:12px;
+  }
+  .row-top-actions{display:flex;gap:10px}
+
+  .input{
+    width:100%;
+    height:48px;
+    background:rgba(13,22,40,.92);
+    border:1px solid rgba(108,139,255,.4);
+    border-radius:var(--field-radius);
+    padding:0 16px;
+    color:var(--ink);
+    font-size:15px;
+    transition:border .2s ease, box-shadow .2s ease, background .2s ease;
+  }
+  .input:focus-visible{
+    outline:none;
+    border-color:rgba(132,159,255,.85);
+    background:rgba(19,30,52,.95);
+    box-shadow:0 0 0 4px rgba(108,139,255,.22);
+  }
+  .btn{
+    height:48px;
+    padding:0 22px;
+    border:0;
+    border-radius:var(--field-radius);
+    font-weight:700;
+    letter-spacing:.01em;
+    cursor:pointer;
+    transition:transform .15s ease, box-shadow .2s ease, background .2s ease;
+  }
+  .btn.primary{
+    background:linear-gradient(135deg,var(--brand),var(--brand-strong));
+    color:#fff;
+    box-shadow:0 18px 30px rgba(108,139,255,.35);
+  }
+  .btn.secondary{
+    background:rgba(12,22,40,.82);
+    border:1px solid rgba(108,139,255,.35);
+    color:var(--ink);
+  }
+  .btn:disabled{opacity:.55;cursor:not-allowed;box-shadow:none}
+  .btn:active{transform:scale(.97)}
+
+  .list{display:flex;flex-direction:column;gap:20px}
+  .emptyState{
+    padding:30px;
+    text-align:center;
+    border:1px dashed rgba(108,139,255,.45);
+    border-radius:var(--radius);
+    background:rgba(10,18,32,.78);
+    color:var(--muted);
+    font-weight:600;
+    letter-spacing:.02em;
+  }
+
+  .secHeader{
+    position:sticky;
+    top:calc(var(--header-offset) + 88px);
+    display:flex;
+    align-items:center;
+    gap:12px;
+    padding:12px 16px;
+    border-radius:var(--field-radius);
+    background:rgba(12,22,40,.88);
+    border:1px solid var(--line);
+    backdrop-filter:blur(14px);
+    box-shadow:var(--shadow);
+    z-index:5;
+  }
+  .secHeader.collapsed{opacity:.75}
+  .secHeader strong{font-size:14px;letter-spacing:.08em;text-transform:uppercase}
+  .pill{
+    background:rgba(108,139,255,.18);
+    border:1px solid rgba(108,139,255,.45);
+    color:#dbe4ff;
+    border-radius:999px;
+    padding:4px 12px;
+    font-size:12px;
+    font-weight:700;
+    letter-spacing:.05em;
+  }
+  .secHeader .btn{height:40px;padding:0 14px;font-size:13px}
+
+  .secList{display:flex;flex-direction:column;gap:18px;padding-top:6px;margin-bottom:34px}
+
+  .card{
+    background:linear-gradient(160deg,rgba(11,19,35,.95),rgba(8,14,26,.92));
+    border:1px solid rgba(108,139,255,.18);
+    border-radius:var(--radius);
+    padding:18px;
+    display:flex;
+    flex-direction:column;
+    gap:16px;
+    box-shadow:var(--shadow);
+  }
+  .cardTop{display:flex;align-items:center;flex-wrap:wrap;gap:10px;justify-content:space-between}
+  .tag{
+    background:rgba(108,139,255,.2);
+    border:1px solid rgba(108,139,255,.35);
+    color:#e5ecff;
+    border-radius:999px;
+    padding:4px 12px;
+    font-size:12px;
+    font-weight:700;
+    letter-spacing:.05em;
+    text-transform:uppercase;
+  }
+  .tag-soft{background:rgba(45,212,191,.18);border-color:rgba(45,212,191,.45);color:#befae2}
+  .tag-warn{background:rgba(248,113,113,.18);border-color:rgba(248,113,113,.45);color:#fee2e2}
+
+  .name[contenteditable]{
+    outline:0;
+    border-radius:var(--field-radius);
+    padding:12px 14px;
+    font-size:18px;
+    line-height:1.3;
+    background:rgba(12,22,40,.85);
+    border:1px solid transparent;
+    transition:border .2s ease, box-shadow .2s ease, background .2s ease;
+  }
+  .name[contenteditable]:focus-visible{
+    border-color:rgba(132,159,255,.8);
+    background:rgba(18,28,48,.92);
+    box-shadow:0 0 0 3px rgba(108,139,255,.2);
+  }
+
+  .rowGrid{
+    display:grid;
+    gap:14px;
+    grid-template-columns:repeat(2,minmax(0,1fr));
+    align-items:stretch;
+  }
+  .field{
+    display:flex;
+    align-items:center;
+    gap:12px;
+    padding:14px;
+    border-radius:var(--field-radius);
+    background:rgba(14,24,44,.82);
+    border:1px solid rgba(108,139,255,.18);
+  }
+  .field select{
+    background:transparent;
+    border:0;
+    color:var(--ink);
+    font-size:15px;
+    font-weight:600;
+    width:100%;
+    outline:none;
+    appearance:none;
+  }
+  .field select option{color:#0f172a}
+
+  .qty{justify-content:space-between}
+  .qty input{
+    width:68px;
+    height:42px;
+    text-align:center;
+    border-radius:12px;
+    border:1px solid rgba(108,139,255,.4);
+    background:rgba(8,14,26,.9);
+    color:var(--ink);
+    font-size:16px;
+    font-weight:700;
+  }
+  .qty input::-webkit-outer-spin-button,
+  .qty input::-webkit-inner-spin-button{appearance:none;margin:0}
+  .qty input[type=number]{-moz-appearance:textfield}
+  .iconBtn{
+    width:44px;
+    height:44px;
+    border-radius:14px;
+    border:0;
+    background:linear-gradient(135deg,var(--brand),var(--brand-strong));
+    color:#fff;
+    font-size:20px;
+    font-weight:900;
+    box-shadow:0 14px 28px rgba(108,139,255,.35);
+    cursor:pointer;
+  }
+  .iconBtn:focus-visible{outline:none;box-shadow:0 0 0 3px rgba(108,139,255,.32)}
+
+  .flag{justify-content:space-between}
+  .flag span{font-size:13px;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
+  .switch{
+    display:inline-flex;
+    align-items:center;
+    gap:10px;
+    padding:6px 14px 6px 8px;
+    border-radius:999px;
+    border:1px solid rgba(108,139,255,.35);
+    background:rgba(16,28,52,.75);
+    color:var(--muted);
+    font-size:13px;
+    font-weight:700;
+    letter-spacing:.08em;
+    cursor:pointer;
+    transition:background .2s ease,border .2s ease,color .2s ease;
+  }
+  .switch[aria-checked="true"]{
+    background:rgba(108,139,255,.24);
+    border-color:rgba(132,159,255,.6);
+    color:#fff;
+  }
+  .switch span.knob{
+    width:26px;
+    height:26px;
+    border-radius:50%;
+    background:linear-gradient(135deg,#fff,#e7edff);
+    box-shadow:0 8px 16px rgba(8,14,26,.5);
+  }
+  .switch[aria-checked="true"] span.knob{background:linear-gradient(135deg,#fff,#dfe6ff)}
+
+  .actions{display:flex;align-items:center;justify-content:center}
+  .delBtn{
+    width:54px;
+    height:54px;
+    border-radius:18px;
+    border:0;
+    background:linear-gradient(135deg,#ff5f6d,#c81e3d);
+    color:#fff;
+    font-weight:800;
+    font-size:22px;
+    box-shadow:0 20px 36px rgba(200,30,61,.45);
+    cursor:pointer;
+  }
+  .delBtn:focus-visible{outline:none;box-shadow:0 0 0 3px rgba(248,113,113,.4)}
+
+  .bar{
+    position:fixed;
+    left:0;right:0;bottom:0;
+    z-index:40;
+    background:linear-gradient(180deg,transparent,rgba(5,8,16,.75) 18%,rgba(5,8,16,.95) 60%);
+    padding:12px 16px calc(18px + env(safe-area-inset-bottom));
+  }
+  .barInner{
+    position:relative;
+    max-width:900px;
+    margin:0 auto;
+    display:flex;
+    gap:12px;
+    background:rgba(11,19,35,.94);
+    border:1px solid rgba(108,139,255,.28);
+    border-radius:26px;
+    padding:14px;
+    box-shadow:var(--shadow);
+    backdrop-filter:blur(16px);
+  }
+  .bar .input{height:48px;font-size:15px}
+  .bar .btn{height:48px}
+  .hintBtn{
+    background:rgba(16,26,46,.85);
+    border:1px solid rgba(108,139,255,.3);
+    color:var(--muted);
+    border-radius:14px;
+    padding:0 16px;
+    height:48px;
+    font-weight:600;
+    letter-spacing:.02em;
+    cursor:pointer;
+  }
+
+  .quickHelp{
+    position:absolute;
+    bottom:calc(100% + 10px);
+    right:0;
+    width:min(340px,90vw);
+    background:rgba(10,18,34,.95);
+    border:1px solid rgba(108,139,255,.35);
+    border-radius:16px;
+    padding:14px 16px;
+    box-shadow:var(--shadow);
+    backdrop-filter:blur(14px);
+    color:var(--muted);
+    font-size:13px;
+    line-height:1.5;
+    z-index:60;
+  }
+  .quickHelp ul{margin:8px 0 0 18px;padding:0}
+  .quickHelp li{margin:4px 0}
+  .quickHelp code{color:#e5ecff;font-weight:600}
+  .quickHelp strong{color:#fff;font-size:14px}
+
+  .toast{
+    position:fixed;
+    bottom:96px;
+    left:50%;
+    transform:translateX(-50%) translateY(12px);
+    background:rgba(11,19,35,.92);
+    border:1px solid rgba(108,139,255,.4);
+    padding:12px 18px;
+    border-radius:16px;
+    font-size:13px;
+    letter-spacing:.05em;
+    text-transform:uppercase;
+    color:#e5ecff;
+    opacity:0;
+    transition:opacity .2s ease, transform .2s ease;
+    box-shadow:var(--shadow);
+    backdrop-filter:blur(12px);
+    z-index:80;
+    pointer-events:none;
+  }
   .toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
+
+  @media (min-width:640px){
+    .row-top{flex-direction:row;align-items:center}
+    .row-top-actions{flex:0 0 auto}
+  }
+  @media (min-width:780px){
+    .wrap{padding-bottom:180px}
+    .rowGrid{grid-template-columns:1.1fr 1fr auto auto auto}
+    .secHeader{top:calc(var(--header-offset) + 100px)}
+    .delBtn{width:48px;height:48px}
+  }
+  @media (max-width:480px){
+    .barInner{flex-direction:column}
+    .bar .btn{width:100%}
+    .row-top-actions{flex-direction:column}
+  }
+  @media (hover:hover){
+    .btn.primary:hover{box-shadow:0 22px 34px rgba(108,139,255,.45)}
+    .btn.secondary:hover{border-color:rgba(132,159,255,.55)}
+    .switch:hover{border-color:rgba(132,159,255,.55)}
+    .delBtn:hover{box-shadow:0 26px 42px rgba(200,30,61,.55)}
+  }
 </style>
 </head>
 <body>
 
-<!-- PASSWORD GATE -->
-<div id="gate" role="dialog" aria-modal="true">
-  <div class="gate-card">
-    <div class="gate-title">Enter password</div>
-    <div class="gate-sub">Ashbaugh–Alomary Grocery List</div>
-    <div class="gate-row">
-      <input id="gateInput" class="gate-input" type="password" placeholder="Password" autofocus/>
-      <button id="gateBtn" class="gate-btn">Unlock</button>
-    </div>
-    <div id="gateErr" class="gate-err"></div>
-  </div>
-</div>
-
-<div class="wrap" id="app" style="display:none">
+<div class="wrap" id="app">
   <header>
-    <div class="logo">🛒</div><h1>Ashbaugh–Alomary Grocery List</h1>
-    <div id="status" class="status off"><span class="dot" style="background:var(--bad)"></span><span id="statusText">Offline</span></div>
+    <div class="logo" aria-hidden="true">🛒</div>
+    <h1>Ashbaugh–Alomary Grocery List</h1>
+    <div id="status" class="status off" role="status" aria-live="polite" aria-atomic="true">
+      <span aria-hidden="true"></span>
+      <span id="statusText">Offline</span>
+    </div>
   </header>
 
-  <div class="seg" role="tablist">
+  <div class="seg" role="tablist" aria-label="List filter">
     <button id="tabActive" class="active" role="tab" aria-selected="true">Shopping</button>
     <button id="tabInactive" role="tab" aria-selected="false">Inactive</button>
   </div>
 
   <div class="row-top">
-    <input id="search" class="input" placeholder="Search items…"/>
-    <button id="copyBtn" class="btn secondary" title="Copy active list">Copy</button>
+    <input id="search" class="input" placeholder="Search items…" type="search" aria-label="Search items"/>
+    <div class="row-top-actions">
+      <button id="copyBtn" class="btn secondary" type="button" title="Copy active list">Copy list</button>
+    </div>
   </div>
 
   <div id="list" class="list"></div>
 </div>
 
-<!-- Sticky Add Bar -->
-<div class="bar">
-  <div class="barInner">
-    <input id="quick" class="input" placeholder="Quick Add: milk x2 @dairy, bread @bakery, apples 4"/>
-    <button id="quickBtn" class="btn">Add</button>
+  <div class="bar">
+    <div class="barInner">
+    <input id="quick" class="input" placeholder="Quick Add: milk x2 @dairy" aria-label="Quick add items"/>
+    <button id="quickBtn" class="btn primary" type="button">Add</button>
+    <button id="hintBtn" class="hintBtn" type="button" aria-expanded="false" aria-controls="quickHelp">Syntax</button>
+    <div id="quickHelp" class="quickHelp" hidden>
+      <strong>Quick add tips</strong>
+      <ul>
+        <li>Separate items with commas.</li>
+        <li>Use <code>x2</code> or <code>*2</code> for quantity.</li>
+        <li>Add <code>@dairy</code> to target a section.</li>
+      </ul>
+    </div>
   </div>
 </div>
 
 <div id="toast" class="toast">Saved</div>
 
-<!-- Firebase -->
 <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-database.js"></script>
 
 <script>
-/*** Password gate ***/
-const PASSWORD_HASH = "REPLACE_WITH_SHA256_HEX";
-async function sha256Hex(t){const b=new TextEncoder().encode(t);const h=await crypto.subtle.digest('SHA-256',b);return Array.from(new Uint8Array(h)).map(x=>x.toString(16).padStart(2,'0')).join('')}
-async function tryUnlock(){const v=document.getElementById('gateInput').value||"";if((await sha256Hex(v))===PASSWORD_HASH){sessionStorage.setItem('grocery_authed','1');document.getElementById('gate').classList.add('hidden');document.getElementById('app').style.display='block';initFirebase();}else{document.getElementById('gateErr').textContent='Incorrect password';}}
-document.getElementById('gateBtn').onclick=tryUnlock;
-document.getElementById('gateInput').addEventListener('keypress',e=>{ if(e.key==='Enter') tryUnlock(); });
-if(sessionStorage.getItem('grocery_authed')==='1'){document.getElementById('gate').classList.add('hidden');document.getElementById('app').style.display='block';setTimeout(initFirebase,0);}
-
-/*** App state ***/
 const listId='beans-main-list';
 const SECTIONS=['Bakery','Dairy','Deli','Produce','Meat','Frozen','Other'];
 let database=null, grocery={}, filter='', showActive=true;
+const BUILD_VERSION='2024-03-11T00:00:00Z';
+document.body.dataset.build=BUILD_VERSION;
+console.info('Grocery UI build',BUILD_VERSION);
 
 const qs=(s,el=document)=>el.querySelector(s);
-const toast=(t='Saved')=>{ const el=document.getElementById('toast'); el.textContent=t; el.classList.add('show'); setTimeout(()=>el.classList.remove('show'),800); if(navigator.vibrate) navigator.vibrate(8); };
+const toast=(t='Saved')=>{
+  const el=document.getElementById('toast');
+  el.textContent=t;
+  el.classList.add('show');
+  setTimeout(()=>el.classList.remove('show'),1100);
+  if(navigator.vibrate) navigator.vibrate(10);
+};
 const clampInt=(v,d=1)=>{ const n=parseInt(v,10); return Number.isFinite(n)&&n>0? n:d; };
 
-/*** Firebase init ***/
 function initFirebase(){
   const cfg={ apiKey:"AIzaSyCQpMDkuFNc1jWH1I_WQZ8Ev2UA2HgEGCI",
     authDomain:"grocery-list-44616.firebaseapp.com",
@@ -161,32 +518,38 @@ function initFirebase(){
     projectId:"grocery-list-44616" };
   if(!firebase.apps.length) firebase.initializeApp(cfg);
   firebase.auth().onAuthStateChanged(u=>{
-    if(u){ database=firebase.database(); attach(); } else { firebase.auth().signInAnonymously().catch(console.error); }
+    if(u){ database=firebase.database(); attach(); }
+    else { firebase.auth().signInAnonymously().catch(console.error); }
   });
 }
 function attach(){
   database.ref(`lists/${listId}/items`).on('value', snap=>{
-    grocery=snap.val()||{}; render(); setOnline(true);
-  }, err=>{ console.error(err); setOnline(false);});
+    grocery=snap.val()||{};
+    render();
+    setOnline(true);
+  }, err=>{ console.error(err); setOnline(false); });
   database.ref('.info/connected').on('value', s=> setOnline(s.val()===true));
 }
 function setOnline(on){
-  const st=qs('#status'), tx=qs('#statusText'), dot=st.querySelector('.dot');
-  if(on){ st.classList.remove('off'); tx.textContent='Connected'; dot.style.background='var(--ok)'; }
-  else  { st.classList.add('off'); tx.textContent='Offline';  dot.style.background='var(--bad)'; }
+  const st=qs('#status'), tx=qs('#statusText'), dot=st.querySelector('span[aria-hidden="true"]');
+  st.classList.toggle('off',!on);
+  tx.textContent = on? 'Connected' : 'Offline';
+  dot.style.background = on? 'var(--accent)' : 'var(--warn)';
+  dot.style.boxShadow = on? '0 0 0 3px rgba(45,212,191,.22)' : '0 0 0 3px rgba(248,113,113,.22)';
 }
 
-/*** Quick Add ***/
 function parseQuick(str){
   return str.split(',').map(p=>p.trim()).filter(Boolean).map(tok=>{
     let name=tok, qty=1, sec='';
-    const mSec=tok.match(/@([a-z]+)$/i); if(mSec){ sec=mSec[1]; name=tok.replace(/@([a-z]+)$/i,'').trim(); }
+    const mSec=tok.match(/@([a-z]+)$/i);
+    if(mSec){ sec=mSec[1]; name=tok.replace(/@([a-z]+)$/i,'').trim(); }
     const mQty=name.match(/(?:x|\*)\s*(\d+)$/i) || name.match(/(\d+)$/);
     if(mQty){ qty=parseInt(mQty[1],10)||1; name=name.replace(mQty[0],'').trim(); }
     const section = SECTIONS.find(s=>s.toLowerCase()===(sec||'').toLowerCase()) || 'Other';
     return {name, section, quantity:qty};
   }).filter(it=>it.name.length>0);
 }
+
 function upsertItem({name,section,quantity}){
   const entries=Object.entries(grocery);
   const found=entries.find(([id,it])=> it && it.name && it.name.toLowerCase()===name.toLowerCase() && it.section===section);
@@ -196,77 +559,140 @@ function upsertItem({name,section,quantity}){
       quantity: clampInt((it.quantity||0)+clampInt(quantity,1),1),
       active:true,lastUpdated:Date.now()
     });
-  }else{
-    const it={name,section,quantity:clampInt(quantity,1),purchased:false,active:true,createdAt:Date.now()};
-    return database.ref(`lists/${listId}/items`).push(it);
   }
+  const it={name,section,quantity:clampInt(quantity,1),purchased:false,active:true,createdAt:Date.now()};
+  return database.ref(`lists/${listId}/items`).push(it);
 }
 
-/*** Render ***/
 function render(){
-  const container=qs('#list'); container.innerHTML='';
+  const container=qs('#list');
+  container.innerHTML='';
   const arr=Object.entries(grocery).map(([id,it])=>({...it,id}));
   const items=arr.filter(it=> showActive ? it.active : !it.active)
                  .filter(it=> filter ? (it.name.toLowerCase().includes(filter) || it.section.toLowerCase().includes(filter)) : true);
 
-  const grouped = SECTIONS.map(sec => [sec, items.filter(it=>it.section===sec)]).filter(([_,g])=>g.length);
-  if(!grouped.length){ const empty=document.createElement('div'); empty.style.color='#9ca3af'; empty.style.padding='16px'; empty.textContent= showActive ? 'No active items.' : 'No inactive items.'; container.appendChild(empty); return; }
+  const grouped=SECTIONS.map(sec=>[sec, items.filter(it=>it.section===sec)]).filter(([_,list])=>list.length);
+  if(!grouped.length){
+    const empty=document.createElement('div');
+    empty.className='emptyState';
+    empty.textContent = showActive ? 'Your shopping list is clear — enjoy the day!' : 'Nothing is resting in inactive.';
+    container.appendChild(empty);
+    return;
+  }
 
-  for(const [sec, group] of grouped){
-    const header=document.createElement('div'); header.className='secHeader';
+  for(const [sec,group] of grouped){
+    const header=document.createElement('div');
+    header.className='secHeader';
     header.innerHTML=`<strong>${sec}</strong><span class="pill">${group.length}</span>`;
-    const btnCollapse=mkBtn('Collapse','secondary',()=>toggleBlock(listEl,header,sec));
-    const btnMove=mkBtn(showActive?'To Inactive':'Reactivate','secondary',()=>bulkActive(sec,!showActive));
-    header.append(btnCollapse,btnMove);
+    const sectionSlug=sec.toLowerCase().replace(/[^a-z0-9]+/g,'-');
+    const collapseBtn=mkBtn('Hide','secondary',()=>toggleBlock(listEl,header,sec,collapseBtn));
+    collapseBtn.setAttribute('aria-expanded','true');
+    collapseBtn.setAttribute('aria-controls',`section-${sectionSlug}`);
+    const moveBtn=mkBtn(showActive?'To inactive':'Reactivate','secondary',()=>bulkActive(sec,!showActive));
+    header.append(collapseBtn,moveBtn);
     container.appendChild(header);
 
     const listEl=document.createElement('div');
-    group.forEach(it => listEl.appendChild(rowCard(it)));
+    listEl.className='secList';
+    listEl.id=`section-${sectionSlug}`;
+    group.forEach(it=> listEl.appendChild(rowCard(it)));
     container.appendChild(listEl);
   }
 }
-function mkBtn(label,type,fn){ const b=document.createElement('button'); b.className='btn '+(type||''); b.textContent=label; b.onclick=fn; return b; }
-function toggleBlock(el,head,sec){ const vis=el.style.display!=='none'; el.style.display=vis?'none':'block'; head.firstChild.textContent=(vis?'▶ ':'')+sec; }
+
+function mkBtn(label,type,fn){
+  const b=document.createElement('button');
+  b.className=`btn ${type||''}`.trim();
+  b.type='button';
+  b.textContent=label;
+  b.onclick=fn;
+  return b;
+}
+function toggleBlock(el,head,sec,btn){
+  const collapsed=el.hasAttribute('hidden');
+  if(collapsed){
+    el.removeAttribute('hidden');
+    head.classList.remove('collapsed');
+    head.querySelector('strong').textContent=sec;
+    btn.textContent='Hide';
+    btn.setAttribute('aria-expanded','true');
+  }else{
+    el.setAttribute('hidden','');
+    head.classList.add('collapsed');
+    head.querySelector('strong').textContent=`▶ ${sec}`;
+    btn.textContent='Show';
+    btn.setAttribute('aria-expanded','false');
+  }
+}
 
 function rowCard(it){
   const c=document.createElement('div'); c.className='card';
 
-  // 1) Name (editable)
-  const name=document.createElement('div'); name.className='name'; name.contentEditable='true'; name.textContent=it.name;
-  name.addEventListener('blur',()=>{ const v=name.textContent.trim(); if(v && v!==it.name){ database.ref(`lists/${listId}/items/${it.id}`).update({name:v}).then(()=>toast()); } else { name.textContent=it.name; }});
+  const top=document.createElement('div'); top.className='cardTop';
+  const sectionTag=document.createElement('span'); sectionTag.className='tag'; sectionTag.textContent=it.section;
+  top.appendChild(sectionTag);
+  if(it.purchased){ const tag=document.createElement('span'); tag.className='tag tag-soft'; tag.textContent='Purchased'; top.appendChild(tag); }
+  if(!it.active){ const tag=document.createElement('span'); tag.className='tag tag-warn'; tag.textContent='Inactive'; top.appendChild(tag); }
+  c.appendChild(top);
+
+  const name=document.createElement('div');
+  name.className='name';
+  name.contentEditable='true';
+  name.textContent=it.name;
+  name.addEventListener('blur',()=>{
+    const v=name.textContent.trim();
+    if(v && v!==it.name){
+      database.ref(`lists/${listId}/items/${it.id}`).update({name:v}).then(()=>toast('Renamed'));
+    }else{
+      name.textContent=it.name;
+    }
+  });
   c.appendChild(name);
 
-  // 2) Grid line: Section | Qty | Purchased | Active | Delete
   const g=document.createElement('div'); g.className='rowGrid';
 
-  // Section
-  const sec=document.createElement('div');
-  const sel=document.createElement('select'); sel.className='select';
+  const sec=document.createElement('div'); sec.className='field';
+  const sel=document.createElement('select');
   SECTIONS.forEach(s=> sel.add(new Option(s,s,s===it.section,s===it.section)));
-  sel.onchange=()=> database.ref(`lists/${listId}/items/${it.id}`).update({section:sel.value}).then(()=>toast());
+  sel.onchange=()=> database.ref(`lists/${listId}/items/${it.id}`).update({section:sel.value}).then(()=>{ sectionTag.textContent=sel.value; toast('Moved'); });
   sec.appendChild(sel); g.appendChild(sec);
 
-  // Quantity
-  const qty=document.createElement('div'); qty.className='qty';
-  const minus=iconBtn('−',()=> setQty(it.id,(it.quantity||1)-1));
-  const q=document.createElement('input'); q.value=it.quantity||1; q.onblur=()=> setQty(it.id,q.value); q.onkeypress=(e)=>{ if(e.key==='Enter'){ q.blur(); } };
-  const plus=iconBtn('+',()=> setQty(it.id,(it.quantity||1)+1));
+  const qty=document.createElement('div'); qty.className='field qty';
+  const minus=iconBtn('−',()=> setQty(it.id,(it.quantity||1)-1),'Decrease quantity');
+  const q=document.createElement('input'); q.type='number'; q.min='1'; q.step='1'; q.value=it.quantity||1;
+  q.onblur=()=> setQty(it.id,q.value);
+  q.onkeypress=e=>{ if(e.key==='Enter'){ e.preventDefault(); q.blur(); } };
+  const plus=iconBtn('+',()=> setQty(it.id,(it.quantity||1)+1),'Increase quantity');
   qty.append(minus,q,plus); g.appendChild(qty);
 
-  // Purchased toggle
-  const purWrap=document.createElement('div'); purWrap.className='twrap'; purWrap.innerHTML='<span>Purchased</span>';
-  const pur=document.createElement('div'); pur.className='toggle'+(it.purchased?' on':'');
-  pur.onclick=()=> database.ref(`lists/${listId}/items/${it.id}`).update({purchased:!it.purchased}).then(()=>toast());
-  purWrap.appendChild(pur); g.appendChild(purWrap);
+  const purWrap=document.createElement('div'); purWrap.className='field flag';
+  const purLabel=document.createElement('span'); purLabel.textContent='Purchased';
+  const pur=createSwitch(it.purchased,{
+    onText:'Done',
+    offText:'Todo',
+    ariaOn:'Mark as not purchased',
+    ariaOff:'Mark as purchased',
+    onToggle:next=> database.ref(`lists/${listId}/items/${it.id}`).update({purchased:next}).then(()=>toast(next?'Marked done':'Reopened'))
+  });
+  purWrap.append(purLabel,pur); g.appendChild(purWrap);
 
-  // Active toggle
-  const actWrap=document.createElement('div'); actWrap.className='twrap'; actWrap.innerHTML='<span>Active</span>';
-  const act=document.createElement('div'); act.className='toggle'+(it.active?' on':'');
-  act.onclick=()=> database.ref(`lists/${listId}/items/${it.id}`).update({active:!it.active}).then(()=>toast());
-  actWrap.appendChild(act); g.appendChild(actWrap);
+  const actWrap=document.createElement('div'); actWrap.className='field flag';
+  const actLabel=document.createElement('span'); actLabel.textContent='Active';
+  const act=createSwitch(it.active,{
+    onText:'Live',
+    offText:'Rest',
+    ariaOn:'Move to inactive',
+    ariaOff:'Move to active',
+    onToggle:next=> database.ref(`lists/${listId}/items/${it.id}`).update({active:next}).then(()=>toast(next?'Reactivated':'Archived'))
+  });
+  actWrap.append(actLabel,act); g.appendChild(actWrap);
 
-  // Delete
-  const del=document.createElement('div'); const delBtn=document.createElement('button'); delBtn.className='delBtn'; delBtn.textContent='×';
+  const del=document.createElement('div'); del.className='actions';
+  const delBtn=document.createElement('button');
+  delBtn.className='delBtn';
+  delBtn.type='button';
+  delBtn.textContent='×';
+  delBtn.setAttribute('aria-label',`Delete ${it.name}`);
   delBtn.onclick=()=> onDelete(it.id);
   del.appendChild(delBtn); g.appendChild(del);
 
@@ -274,41 +700,119 @@ function rowCard(it){
   return c;
 }
 
-function iconBtn(txt,fn){ const b=document.createElement('button'); b.className='iconBtn'; b.textContent=txt; b.onclick=fn; return b; }
-function setQty(id,val){ const q=clampInt(val,1); return database.ref(`lists/${listId}/items/${id}`).update({quantity:q}).then(()=>toast()); }
-function onDelete(id){ if(confirm('Delete this item?')) database.ref(`lists/${listId}/items/${id}`).remove().then(()=>toast('Deleted')); }
+function createSwitch(initial,{onText='On',offText='Off',ariaOn='Switch off',ariaOff='Switch on',onToggle}){
+  const btn=document.createElement('button');
+  btn.className='switch';
+  btn.type='button';
+  btn.setAttribute('role','switch');
+  const knob=document.createElement('span'); knob.className='knob'; knob.setAttribute('aria-hidden','true');
+  const text=document.createElement('span'); text.className='label';
+  btn.append(knob,text);
 
-/*** Bulk ops ***/
+  const apply=state=>{
+    btn.setAttribute('aria-checked',state?'true':'false');
+    btn.setAttribute('aria-label',state?ariaOn:ariaOff);
+    text.textContent=state?onText:offText;
+  };
+  apply(initial);
+
+  btn.onclick=()=>{
+    if(!onToggle) return;
+    const current=btn.getAttribute('aria-checked')==='true';
+    const next=!current;
+    apply(next);
+    btn.disabled=true;
+    Promise.resolve(onToggle(next))
+      .catch(()=>{ apply(current); toast('Try again'); })
+      .finally(()=>{ btn.disabled=false; });
+  };
+
+  return btn;
+}
+
+function iconBtn(txt,fn,label){
+  const b=document.createElement('button');
+  b.className='iconBtn';
+  b.type='button';
+  b.textContent=txt;
+  if(label) b.setAttribute('aria-label',label);
+  b.onclick=fn;
+  return b;
+}
+function setQty(id,val){
+  const q=clampInt(val,1);
+  return database.ref(`lists/${listId}/items/${id}`).update({quantity:q}).then(()=>toast('Quantity set'));
+}
+function onDelete(id){
+  if(confirm('Delete this item?')){
+    database.ref(`lists/${listId}/items/${id}`).remove().then(()=>toast('Deleted'));
+  }
+}
+
 function bulkActive(section,flag){
-  const updates={}; Object.entries(grocery).forEach(([id,it])=>{ if(it.section===section) updates[`lists/${listId}/items/${id}/active`]=flag; });
+  const updates={};
+  Object.entries(grocery).forEach(([id,it])=>{
+    if(it.section===section) updates[`lists/${listId}/items/${id}/active`]=flag;
+  });
   if(Object.keys(updates).length) database.ref().update(updates).then(()=>toast(flag?'Reactivated':'Archived'));
 }
 
-/*** Controls ***/
 document.getElementById('quickBtn').onclick=()=>{
-  const t=qs('#quick').value.trim(); if(!t) return;
-  const items=parseQuick(t); if(!items.length) return;
-  Promise.all(items.map(upsertItem)).then(()=>{ qs('#quick').value=''; toast('Added'); });
+  const input=qs('#quick');
+  const t=input.value.trim();
+  if(!t){ toast('Add an item name first'); input.focus(); return; }
+  const items=parseQuick(t);
+  if(!items.length){ toast('Try: milk x2 @dairy'); input.focus(); return; }
+  Promise.all(items.map(upsertItem)).then(()=>{ input.value=''; toast('Added'); });
 };
-qs('#quick').addEventListener('keypress',e=>{ if(e.key==='Enter'){ e.preventDefault(); document.getElementById('quickBtn').click(); }});
+qs('#quick').addEventListener('keypress',e=>{
+  if(e.key==='Enter'){ e.preventDefault(); document.getElementById('quickBtn').click(); }
+});
 qs('#search').addEventListener('input',e=>{ filter=e.target.value.trim().toLowerCase(); render(); });
 
-qs('#tabActive').onclick=()=>{ showActive=true; tabSet(true); render(); };
-qs('#tabInactive').onclick=()=>{ showActive=false; tabSet(false); render(); };
+document.getElementById('tabActive').onclick=()=>{ showActive=true; tabSet(true); render(); };
+document.getElementById('tabInactive').onclick=()=>{ showActive=false; tabSet(false); render(); };
 function tabSet(active){
-  qs('#tabActive').classList.toggle('active', active);
-  qs('#tabInactive').classList.toggle('active', !active);
-  qs('#tabActive').setAttribute('aria-selected', active?'true':'false');
-  qs('#tabInactive').setAttribute('aria-selected', !active?'true':'false');
+  qs('#tabActive').classList.toggle('active',active);
+  qs('#tabInactive').classList.toggle('active',!active);
+  qs('#tabActive').setAttribute('aria-selected',active?'true':'false');
+  qs('#tabInactive').setAttribute('aria-selected',!active?'true':'false');
 }
 
-/* Copy active list */
+const hintBtn=qs('#hintBtn');
+const hintPanel=qs('#quickHelp');
+const setHintVisible=(visible)=>{
+  if(visible){
+    hintPanel.removeAttribute('hidden');
+    hintBtn.setAttribute('aria-expanded','true');
+  }else{
+    hintPanel.setAttribute('hidden','');
+    hintBtn.setAttribute('aria-expanded','false');
+  }
+};
+hintBtn.addEventListener('click',()=>{
+  const expanded=hintPanel.hasAttribute('hidden');
+  setHintVisible(expanded);
+});
+document.addEventListener('click',ev=>{
+  if(hintPanel.hasAttribute('hidden')) return;
+  if(!qs('.barInner').contains(ev.target) || ev.target===hintBtn){
+    if(ev.target!==hintBtn) setHintVisible(false);
+  }
+});
+document.addEventListener('keydown',ev=>{
+  if(ev.key==='Escape' && !hintPanel.hasAttribute('hidden')) setHintVisible(false);
+});
+
 qs('#copyBtn').onclick=async()=>{
-  const active = Object.values(grocery).filter(it=>it.active && !it.purchased);
-  const txt = active.map(it=>`${it.name} x${it.quantity} [${it.section}]`).join('\n');
+  const active=Object.values(grocery).filter(it=>it.active && !it.purchased);
+  const txt=active.map(it=>`${it.name} x${it.quantity} [${it.section}]`).join('\n');
+  if(!txt){ toast('No items to copy'); return; }
   await navigator.clipboard.writeText(txt);
   toast('Copied');
 };
+
+initFirebase();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the grocery layout with a sticky header, pill tabs, tactile cards, and a floating quick-add bar plus syntax helper for mobile users
- remove the password gate so the list loads immediately and show clearer connection status along with quick-add validation toasts
- modernize item controls with accessible switch buttons, inline quantity steppers, and safer copy-to-clipboard feedback
- add cache-busting meta tags and a build stamp so browsers fetch the refreshed interface

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68ceabf9e92483288a5bff60fb0d0a2d